### PR TITLE
Add detection for naws, mssp, mccp, mxp, zmp to option parser

### DIFF
--- a/lib/telnet/options.ex
+++ b/lib/telnet/options.ex
@@ -20,10 +20,14 @@ defmodule Telnet.Options do
 
   @echo 1
   @term_type 24
+  @naws 31
   @line_mode 34
   @new_environ 39
   @charset 42
   @mssp 70
+  @mccp2 86
+  @mxp 91
+  @zmp 93
   @oauth 165
   @gmcp 201
 
@@ -284,6 +288,8 @@ defmodule Telnet.Options do
 
   def byte_to_option(@term_type), do: :term_type
 
+  def byte_to_option(@naws), do: :naws
+
   def byte_to_option(@line_mode), do: :line_mode
 
   def byte_to_option(@new_environ), do: :new_environ
@@ -291,6 +297,12 @@ defmodule Telnet.Options do
   def byte_to_option(@charset), do: :charset
 
   def byte_to_option(@mssp), do: :mssp
+
+  def byte_to_option(@mccp2), do: :mccp2
+
+  def byte_to_option(@mxp), do: :mxp
+
+  def byte_to_option(@zmp), do: :zmp
 
   def byte_to_option(@oauth), do: :oauth
 
@@ -329,6 +341,8 @@ defmodule Telnet.Options do
 
   def option_to_byte(:term_type), do: @term_type
 
+  def option_to_byte(:naws), do: @naws
+
   def option_to_byte(:line_mode), do: @line_mode
 
   def option_to_byte(:new_environ), do: @new_environ
@@ -336,6 +350,12 @@ defmodule Telnet.Options do
   def option_to_byte(:charset), do: @charset
 
   def option_to_byte(:mssp), do: @mssp
+
+  def option_to_byte(:mccp2), do: @mccp2
+
+  def option_to_byte(:mxp), do: @mxp
+
+  def option_to_byte(:zmp), do: @zmp
 
   def option_to_byte(:oauth), do: @oauth
 


### PR DESCRIPTION
Added configuration for some options used by the [discworld mud](http://discworld.starturtle.net/lpc/). Some of these are not common general telnet options, but this library appears to be intended for mud connections.

* `naws` Negotiate About Window Size - [RFC 1073](https://datatracker.ietf.org/doc/html/rfc1073)
  Allows the client to set height/width with the mud, so line breaks in the expected place and to avoid client-side scrolling if desired. Calling it `:naws` is terse and jargony but `:negotiate_about_window_size` would have made it the longest opt keyword by a large margin, but may still be a better choice. Let me know if you'd prefer that and I'll swap it.

*  `mccp2` Mud Client Compression Protocol - [tintin documentation](https://tintin.mudhalla.net/protocols/mccp/)
  zlib compression of mud text data. Mudlet also supports this so I think it is in real use on other muds as well.

* `mxp` Mud eXtension Protocol - [zmud documentation](http://www.zuggsoft.com/zmud/mxp.htm)
  In practice I think this is only used now for sending clickable links via [MSLP](https://tintin.mudhalla.net/protocols/mslp/). I'm a little confused on the difference or overlap between this and MSLP actually. But since it's sent as a separate opt from the mud it might as well be parsed.

* `zmp` Zenith Mud Protocol - [can't find much about this one](https://github.com/Mudlet/Mudlet/issues/1236)
   I think this is a failed or unpopular alternative to GMCP for sending out of bounds data. Mudlet supports it for completeness, since at least one other mud uses it. I don't have plans for it but we can at least read & identify the opt in case anyone ever wants it.